### PR TITLE
Introduce Might::FilterParameters as subclass of Set, thus we can def…

### DIFF
--- a/lib/might/fetcher.rb
+++ b/lib/might/fetcher.rb
@@ -1,3 +1,4 @@
+require 'might/filter_parameters'
 require 'might/sort_parameters_extractor'
 require 'might/sort_parameters_validator'
 require 'might/filter_parameters_extractor'
@@ -58,7 +59,7 @@ module Might
     inheritable_attr :sort_parameters_definition
     inheritable_attr :middleware_changes
 
-    self.filter_parameters_definition = Set.new
+    self.filter_parameters_definition = FilterParameters.new
     self.sort_parameters_definition = Set.new
     self.middleware_changes = []
 

--- a/lib/might/filter_parameters.rb
+++ b/lib/might/filter_parameters.rb
@@ -1,0 +1,29 @@
+require 'set'
+
+module Might
+  #
+  class FilterParameters < Set
+    FilterError = Class.new(KeyError)
+
+    # Find filter by name
+    # @param name [String]
+    # @return [Might::FilterParameter, nil]
+    #
+    def [](name)
+      detect { |filter| filter.name == name }
+    end
+
+    # Find filter by name or raise error
+    # @param name [String]
+    # @return [Might::FilterParameter]
+    # @raise FilterError
+    #
+    def fetch(name)
+      if (filter = self[name])
+        filter
+      else
+        fail FilterError, "filter not found: #{name.inspect}"
+      end
+    end
+  end
+end

--- a/spec/might/fetcher_filter_dsl_spec.rb
+++ b/spec/might/fetcher_filter_dsl_spec.rb
@@ -1,6 +1,7 @@
 require 'set'
 require 'might/fetcher'
 require 'might/filter_parameter_definition'
+require 'might/filter_parameters'
 
 RSpec.describe Might::Fetcher, 'Filter DSL' do
   describe '.filter' do
@@ -9,7 +10,7 @@ RSpec.describe Might::Fetcher, 'Filter DSL' do
     end
 
     before do
-      fetcher_class.filter_parameters_definition = Set.new
+      fetcher_class.filter_parameters_definition = Might::FilterParameters.new
     end
 
     subject { fetcher_class.filter_parameters_definition }

--- a/spec/might/filter_middleware_spec.rb
+++ b/spec/might/filter_middleware_spec.rb
@@ -1,11 +1,11 @@
 require 'might/filter_middleware'
 require 'might/filter_parameter'
 require 'might/filter_parameter_definition'
-require 'set'
+require 'might/filter_parameters'
 require 'database_helper'
 
 RSpec.describe Might::FilterMiddleware, database: true do
-  let(:params) { { filter: Set.new([parameter]) } }
+  let(:params) { { filter: Might::FilterParameters.new([parameter]) } }
   let(:page) { Page.first }
   let(:parameter) { Might::FilterParameter.new(page.name, 'eq', definition) }
   let(:definition) do

--- a/spec/might/filter_parameters_extractor_spec.rb
+++ b/spec/might/filter_parameters_extractor_spec.rb
@@ -3,13 +3,14 @@ require 'might/filter_parameters_extractor'
 require 'might/filter_predicates'
 require 'might/filter_parameter_definition'
 require 'might/filter_parameter'
+require 'might/filter_parameters'
 
 RSpec.describe Might::FilterParametersExtractor do
   context '#call' do
     # @param parameters_definition [Might::FilterParameterDefinition]
     def extractor(parameters_definition)
       app = ->(env) { env[0] }
-      described_class.new(app, Set.new([parameters_definition]))
+      described_class.new(app, Might::FilterParameters.new([parameters_definition]))
     end
 
     def extract(parameter_definition, params)

--- a/spec/might/filter_parameters_spec.rb
+++ b/spec/might/filter_parameters_spec.rb
@@ -1,0 +1,51 @@
+require 'might/filter_parameters'
+require 'might/filter_parameter_definition'
+require 'might/filter_parameter'
+
+RSpec.describe Might::FilterParameters do
+  let(:parameter_definition) { Might::FilterParameterDefinition.new(:height) }
+  let(:parameter) { Might::FilterParameter.new('146', 'eq', parameter_definition) }
+  let(:filter_parameters) { described_class.new([parameter]) }
+
+  describe '#[]' do
+    subject { filter_parameters[parameter_name] }
+
+    context 'when existing parameter name given' do
+      let(:parameter_name) { 'height' }
+
+      it 'returns parameter with this name' do
+        is_expected.to eq(parameter)
+      end
+    end
+
+    context 'when parameter name given is absent' do
+      let(:parameter_name) { 'width' }
+
+      it 'returns parameter with this name' do
+        is_expected.to be_nil
+      end
+    end
+  end
+
+  describe '#fetch' do
+    subject(:fetch) { filter_parameters.fetch(parameter_name) }
+
+    context 'when existing parameter name given' do
+      let(:parameter_name) { 'height' }
+
+      it 'returns parameter with this name' do
+        is_expected.to eq(parameter)
+      end
+    end
+
+    context 'when parameter name given is absent' do
+      let(:parameter_name) { :width }
+
+      it 'returns parameter with this name' do
+        expect do
+          fetch
+        end.to raise_error(Might::FilterParameters::FilterError, 'filter not found: :width')
+      end
+    end
+  end
+end


### PR DESCRIPTION
…ine domain specific methods:

```ruby
filters = Might::FilterParameters.new([parameter])

filters['height'] #=> #<Might::FilterParameter ....>
fitlers['width'] #=> nil

fitlers.fetch('height') #=>  #<Might::FilterParameter ....>
fitlers.fetch(:width) #=> fails with Might::FilterParameters::FilterError
```