### PR TITLE
Feature/implement filter parameters delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**0.7.0**
+
+  * Allow to pass block to `FilterParameter#fetch` to customize not found behaviour.
+  * Implement `FilterParameter#delete`.
+  * `FilterParameters` is not derived from `Set` anymore.
+
 **0.6.1**
 
   * Add error message to `Failure#get`

--- a/lib/might/filter_parameters.rb
+++ b/lib/might/filter_parameters.rb
@@ -65,7 +65,7 @@ module Might
 
     # Delete filter by name
     # @param name [String]
-    # @return [Might::FilterParameter]
+    # @return [Might::FilterParameter, nil]
     def delete(name)
       filter_parameter = self[name]
       parameters.delete(filter_parameter) if filter_parameter

--- a/lib/might/filter_parameters.rb
+++ b/lib/might/filter_parameters.rb
@@ -1,33 +1,83 @@
 require 'set'
+require 'forwardable'
 
 module Might
   #
-  class FilterParameters < Set
+  class FilterParameters
+    include Comparable
+    include Enumerable
+    extend Forwardable
+
     FilterError = Class.new(KeyError)
+
+    def_delegators :parameters, :detect, :each
+
+    # @param [<Might::FilterParameter>]
+    def initialize(parameters = nil)
+      @parameters = Set.new(parameters)
+    end
 
     # Find filter by name
     # @param name [String]
     # @return [Might::FilterParameter, nil]
     #
     def [](name)
-      detect { |filter| filter.name == name }
+      parameters.detect { |filter| filter.name == name }
     end
 
     # Find filter by name or raise error
     # @param name [String]
+    # @yieldparam name [String]
+    #   block value will be returned if no `FilterParameter` found with specified name
     # @return [Might::FilterParameter]
     # @raise FilterError
     #
     def fetch(name)
       if (filter = self[name])
         filter
+      elsif block_given?
+        yield(name)
       else
         fail FilterError, "filter not found: #{name.inspect}"
       end
     end
 
-    def map(&block)
-      dup.map!(&block)
+    # param value [Might::FilterParameter]
+    def add(value)
+      self.class.new(parameters.add(value))
     end
+
+    alias << add
+
+    def map(&block)
+      self.class.new(parameters.map(&block))
+    end
+
+    # param other [Might::FilterParameters]
+    def -(other)
+      self.class.new(parameters - other.parameters)
+    end
+
+    # param other [Might::FilterParameters]
+    def +(other)
+      self.class.new(parameters.merge(other.parameters))
+    end
+
+    # Delete filter by name
+    # @param name [String]
+    # @return [Might::FilterParameter]
+    def delete(name)
+      filter_parameter = self[name]
+      parameters.delete(filter_parameter) if filter_parameter
+      filter_parameter
+    end
+
+    def <=>(other)
+      parameters <=> other.parameters
+    end
+
+    protected
+
+    attr_reader :parameters
   end
 end

--- a/lib/might/version.rb
+++ b/lib/might/version.rb
@@ -1,4 +1,4 @@
 #
 module Might
-  VERSION = '0.6.1'.freeze
+  VERSION = '0.7.0'.freeze
 end

--- a/spec/might/filter_parameters_spec.rb
+++ b/spec/might/filter_parameters_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe Might::FilterParameters do
   let(:parameter) { Might::FilterParameter.new('146', 'eq', parameter_definition) }
   let(:filter_parameters) { described_class.new([parameter]) }
 
+  shared_examples 'returns new object' do
+    it 'returns another object of the same type' do
+      is_expected.to be_kind_of(Might::FilterParameters)
+      is_expected.not_to equal(filters)
+    end
+  end
+
   describe '#[]' do
     subject { filter_parameters[parameter_name] }
 
@@ -41,11 +48,94 @@ RSpec.describe Might::FilterParameters do
     context 'when parameter name given is absent' do
       let(:parameter_name) { :width }
 
-      it 'returns parameter with this name' do
+      it 'fails with filter error' do
         expect do
           fetch
         end.to raise_error(Might::FilterParameters::FilterError, 'filter not found: :width')
       end
+    end
+
+    context 'with optional block passed' do
+      NoSuchFilterError = Class.new(StandardError)
+      subject(:fetch) do
+        filter_parameters.fetch(parameter_name) do |name|
+          fail NoSuchFilterError, name
+        end
+      end
+
+      context 'when existing parameter name given' do
+        let(:parameter_name) { 'height' }
+
+        it 'returns parameter with this name' do
+          is_expected.to eq(parameter)
+        end
+      end
+
+      context 'when parameter name given is absent' do
+        let(:parameter_name) { :width }
+
+        it 'returns block value' do
+          expect do
+            fetch
+          end.to raise_error(NoSuchFilterError, 'width')
+        end
+      end
+    end
+  end
+
+  describe '#delete' do
+    subject(:delete) { filter_parameters.delete(parameter_name) }
+
+    context 'when existing parameter name given' do
+      let(:parameter_name) { 'height' }
+
+      it 'returns parameter with this name' do
+        is_expected.to eq(parameter)
+        expect(filter_parameters[parameter_name]).to eq(nil)
+      end
+    end
+
+    context 'when parameter name given is absent' do
+      let(:parameter_name) { :width }
+
+      it 'returns nil' do
+        is_expected.to eq(nil)
+      end
+    end
+  end
+
+  describe '#-' do
+    let(:filters) { Might::FilterParameters.new([1, 2]) }
+    let(:other_filters) { Might::FilterParameters.new([1, 3]) }
+    subject(:subtraction) { filters - other_filters }
+
+    include_examples 'returns new object'
+
+    it 'result object contains values not in second object' do
+      is_expected.to eq(Might::FilterParameters.new([2]))
+    end
+  end
+
+  describe '#+' do
+    let(:filters) { Might::FilterParameters.new([1, 2]) }
+    let(:other_filters) { Might::FilterParameters.new([1, 3]) }
+    subject(:addition) { filters + other_filters }
+
+    include_examples 'returns new object'
+
+    it 'result object contains values from both objects' do
+      is_expected.to eq(Might::FilterParameters.new([1, 2, 3]))
+    end
+  end
+
+  describe '#add' do
+    let(:filters) { Might::FilterParameters.new([1, 2]) }
+    subject(:add) { filters.add(3) }
+
+    include_examples 'returns new object'
+
+    it 'result object contains values from original object plus added value' do
+      is_expected.to eq(Might::FilterParameters.new([1, 2, 3]))
     end
   end
 
@@ -53,10 +143,7 @@ RSpec.describe Might::FilterParameters do
     let(:filters) { Might::FilterParameters.new([1, 2]) }
     subject(:mapped) { filters.map { |v| v * 2 } }
 
-    it 'returns another object of the same type' do
-      is_expected.to be_kind_of(Might::FilterParameters)
-      is_expected.not_to equal(filters)
-    end
+    include_examples 'returns new object'
 
     it 'maps values inside container' do
       is_expected.to eq(Might::FilterParameters.new([2, 4]))


### PR DESCRIPTION
Because Set interface is too wide and some methods e.g. Set#- internally uses other methods just overriding FilterParameters#delete broke FilterParameters#-
    
Now FilterParameters class uses composition on Set instead inheritance and have more narrow and predictable interface.